### PR TITLE
Always keep info datum; requires title

### DIFF
--- a/app/Http/Requests/ProfileUpdateRequest.php
+++ b/app/Http/Requests/ProfileUpdateRequest.php
@@ -35,6 +35,7 @@ class ProfileUpdateRequest extends FormRequest
         return [
             'full_name' => 'required|string',
             'public' => 'required|boolean',
+            'data.*.data.title' => 'required|string',
             'data.*.data.email' => 'nullable|email',
             'data.*.data.url' => 'nullable|url',
             'data.*.data.secondary_url' => 'nullable|url',
@@ -67,6 +68,7 @@ class ProfileUpdateRequest extends FormRequest
     {
         return [
             'full_name' => 'Display Name',
+            'data.*.data.title' => 'Title',
             'data.*.data.email' => 'Email address',
             'data.*.data.url' => 'Primary URL',
             'data.*.data.secondary_url' => 'Secondary URL',

--- a/app/Profile.php
+++ b/app/Profile.php
@@ -214,6 +214,9 @@ class Profile extends Model implements HasMedia, Auditable
                 $record->data = $entry['data'];
               }
               $record->sort_order = $sort_order--;
+              if ($record->type === 'information') {
+                  $should_save = true;
+              }
           }
           //new records
           else if($should_save){
@@ -238,7 +241,7 @@ class Profile extends Model implements HasMedia, Auditable
                   $record->clearMediaCollection('images');
                   $record->addMedia($new_file)->toMediaCollection('images');
               }
-          } elseif ($record !== null) {
+          } elseif ($record instanceof ProfileData && $record->type !== 'information') {
               $record->delete();
           }
 

--- a/resources/views/profiles/edit/information.blade.php
+++ b/resources/views/profiles/edit/information.blade.php
@@ -49,7 +49,8 @@
 			<div class="form-group">
 				<input type="hidden" name="data[{{$info->id}}][id]"  value="{{$info->id}}" />
 				<label for="data[{{$info->id}}][data][title]">Title</label>
-				<input type="text" class="form-control" name="data[{{$info->id}}][data][title]" id="data[{{$info->id}}][data][title]" value="{{$info->title}}"  />
+				<input type="text" class="form-control" name="data[{{$info->id}}][data][title]" id="data[{{$info->id}}][data][title]" value="{{$info->title}}" required />
+				{!! Form::inlineErrors("data.".$info->id.".data.title") !!}
 			</div>
 			<div class="form-group">
 				<label for="data[{{$info->id}}][data][distinguished_title]">Distinguished Title</label>


### PR DESCRIPTION
When updating information, we should make sure to not delete the ProfileData record for it. This also makes the title field required, so that there's always at least that data in the record.

Fixes PROFILES-3X, PROFILES-3Y, PROFILES-40, PROFILES-41