### PR TITLE
Config global mail reply to

### DIFF
--- a/config/mail.php
+++ b/config/mail.php
@@ -84,7 +84,23 @@ return [
     */
 
     'from' => [
-        'address' => env('MAIL_FROM_ADDRESS', 'hello@example.com'),
+        'address' => env('MAIL_FROM_ADDRESS', 'From'),
+        'name' => env('MAIL_FROM_NAME', 'Profiles'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Global "Reply to" Address
+    |--------------------------------------------------------------------------
+    |
+    | You may wish for all e-mails sent by your application to be sent from
+    | the same address. Here, you may specify a name and address that is
+    | used globally for all e-mails that are sent by your application.
+    |
+    */
+
+    'reply_to' => [
+        'address' => env('MAIL_REPLY_TO_ADDRESS', 'Reply to'),
         'name' => env('MAIL_FROM_NAME', 'Profiles'),
     ],
 


### PR DESCRIPTION
Sets the MAIL_REPLY_TO_ADDRESS variable on .env to be used by config/mail.php for a global mail reply_to address.