### PR TITLE
Adds Breadcrumbs

### DIFF
--- a/public/css/app.css
+++ b/public/css/app.css
@@ -4545,9 +4545,9 @@ input[type=button].btn-block {
   display: flex;
   flex-wrap: wrap;
   padding: 0.75rem 1rem;
-  margin-bottom: 1rem;
+  margin-bottom: 0;
   list-style: none;
-  background-color: #e9ecef;
+  background-color: #f8f9fa;
 }
 
 .breadcrumb-item + .breadcrumb-item {
@@ -4556,7 +4556,7 @@ input[type=button].btn-block {
 .breadcrumb-item + .breadcrumb-item::before {
   float: left;
   padding-right: 0.5rem;
-  color: #6c757d;
+  color: #6a737b;
   content: "/";
 }
 .breadcrumb-item + .breadcrumb-item:hover::before {
@@ -4566,7 +4566,7 @@ input[type=button].btn-block {
   text-decoration: none;
 }
 .breadcrumb-item.active {
-  color: #6c757d;
+  color: #6a737b;
 }
 
 .pagination {
@@ -10078,6 +10078,10 @@ footer > ul {
   border: none;
 }
 
+.breadcrumb .breadcrumb-item a {
+  color: #008441;
+}
+
 .profile-card {
   margin-bottom: 2rem;
   width: 16rem;
@@ -10101,12 +10105,13 @@ footer > ul {
 
 .profile {
   background-color: #f8f9fa;
+  padding-top: 3px;
 }
 .profile .profile-header {
   background-color: #fff;
   padding: 60px 40px 40px;
   margin-bottom: 30px;
-  box-shadow: 2px 2px 4px #dee2e6;
+  box-shadow: 0px 0px 6px #dee2e6;
 }
 .profile .profile-header .profile_summary {
   color: #555555;

--- a/public/mix-manifest.json
+++ b/public/mix-manifest.json
@@ -1,6 +1,6 @@
 {
     "/js/app.js": "/js/app.js?id=b97e0046b3c3173a61892478e0c177c2",
     "/js/manifest.js": "/js/manifest.js?id=dc9ead3d7857b522d7de22d75063453c",
-    "/css/app.css": "/css/app.css?id=8049ad569fe5013c5d82511c8c8a9282",
+    "/css/app.css": "/css/app.css?id=5e277f68ff9f31f1902908383f265a59",
     "/js/vendor.js": "/js/vendor.js?id=fd544e04e787f8d741ee219386d45238"
 }

--- a/resources/assets/sass/_breadcrumbs.scss
+++ b/resources/assets/sass/_breadcrumbs.scss
@@ -1,0 +1,11 @@
+//== Breadcrumbs
+
+.breadcrumb {
+
+    .breadcrumb-item {
+
+        a {
+            color: $breadcrumb-link-color;
+        }
+    }
+}

--- a/resources/assets/sass/_profile.scss
+++ b/resources/assets/sass/_profile.scss
@@ -1,12 +1,14 @@
 // profile.show
 
 .profile {
+	background-color: $light;
+	padding-top: 3px;
 
 	.profile-header {
 		background-color: $white;
 		padding: 60px 40px 40px;
 		margin-bottom: 30px;
-		box-shadow: 2px 2px 4px $gray-300;
+		box-shadow: 0px 0px 6px $gray-300;
 
 		.profile_summary {
 			color: $gray;
@@ -194,9 +196,6 @@
 		margin-right: 15px;
 		margin-bottom: 5px;
 	}
-
-	background-color: $light;
-	
 }
 
 //general

--- a/resources/assets/sass/_variables.scss
+++ b/resources/assets/sass/_variables.scss
@@ -1,3 +1,5 @@
+@use "sass:color";
+
 //== Variables
 
 // Options
@@ -198,6 +200,17 @@ $navbar-dark-color:                 rgba($white, 1) !default;
 $navbar-dark-hover-color:           $white !default;
 $navbar-dark-active-color:          $white !default;
 $navbar-dark-disabled-color:        rgba($white, .5) !default;
+
+//== Breadcrumbs
+//
+//## Increase contrast for WCAG AA
+
+$breadcrumb-bg:                     $gray-100 !default;
+$breadcrumb-active-color:           color.scale($gray-600, $lightness: -2%) !default;
+$breadcrumb-divider-color:          $breadcrumb-active-color !default;
+$breadcrumb-link-color:             color.scale($primary, $lightness: -1%) !default;
+
+$breadcrumb-margin-bottom:          0 !default;
 
 //== Forms
 //

--- a/resources/assets/sass/app.scss
+++ b/resources/assets/sass/app.scss
@@ -19,6 +19,7 @@
 // Custom Classes
 @import 'core';
 @import 'header';
+@import 'breadcrumbs';
 @import 'profile_card';
 @import 'profile';
 @import 'tags';

--- a/resources/views/breadcrumbs.blade.php
+++ b/resources/views/breadcrumbs.blade.php
@@ -1,0 +1,10 @@
+<div class="breadcrumbs bg-light mb-0">
+    <nav class="container" aria-label="breadcrumb">
+        <ol class="breadcrumb bg-transparent m-0">
+            <li class="breadcrumb-item">
+                <a href="{{ url('/') }}">Home</a>
+            </li>
+            @stack('breadcrumbs')
+        </ol>
+    </nav>
+</div>

--- a/resources/views/breadcrumbs.blade.php
+++ b/resources/views/breadcrumbs.blade.php
@@ -1,6 +1,6 @@
 <div class="breadcrumbs bg-light mb-0">
     <nav class="container" aria-label="breadcrumb">
-        <ol class="breadcrumb bg-transparent m-0">
+        <ol class="breadcrumb">
             <li class="breadcrumb-item">
                 <a href="{{ url('/') }}">Home</a>
             </li>

--- a/resources/views/faq.blade.php
+++ b/resources/views/faq.blade.php
@@ -1,7 +1,13 @@
 @extends('layout')
 @section('title', 'FAQ')
 @section('header')
-  @include('nav')
+    @include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active" aria-current="page">
+            FAQ
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 
 @section('content')

--- a/resources/views/logs/index.blade.php
+++ b/resources/views/logs/index.blade.php
@@ -2,6 +2,15 @@
 @section('title', 'Activity Logs')
 @section('header')
 	@include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            Admin
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            Activity Logs
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 <div class="container">

--- a/resources/views/nav.blade.php
+++ b/resources/views/nav.blade.php
@@ -10,6 +10,7 @@ $can_create_own_profile = $user && $user->can('createOwn', 'App\Profile');
 $can_view_profile_admin_index = $user && $user->can('viewAdminIndex', 'App\Profile');
 $can_view_school_admin_index = $user && $user->can('viewAdminIndex', 'App\School');
 $can_view_user_admin_index = $user && $user->can('viewAdminIndex', 'App\User');
+$can_view_delegation_admin_index = $user && $user->can('viewAdminIndex', App\UserDelegation::class);
 $can_view_tag_admin_index = $user && $user->can('viewAdminIndex', 'Spatie\Tags\Tag');
 $can_view_log_admin_index = $user && $user->can('viewAdminIndex', 'App\LogEntry');
 $can_update_settings = $user && $user->can('update', 'App\Setting');
@@ -58,7 +59,7 @@ $can_create_users = $user && $user->can('create', 'App\User');
           </div>
         </li>
         @endif
-        @if($can_view_user_admin_index || $can_view_tag_admin_index || $can_create_users || $can_view_profile_admin_index || $can_view_log_admin_index || $can_view_school_admin_index || $can_update_settings)
+        @if($can_view_user_admin_index || $can_view_delegation_admin_index || $can_view_tag_admin_index || $can_create_users || $can_view_profile_admin_index || $can_view_log_admin_index || $can_view_school_admin_index || $can_update_settings)
         <li class="nav-item dropdown">
           <a href="#" class="nav-link dropdown-toggle" id="adminNavDropdown" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
             Admin <span class="caret"></span>
@@ -79,9 +80,11 @@ $can_create_users = $user && $user->can('create', 'App\User');
               <span class="fas fa-plus fa-fw"></span> Add User / Profile
             </a>
             @endif
+            @if($can_view_delegation_admin_index)
             <a class="dropdown-item" href="{{ route('users.delegations-index') }}">
               <span class="fas fa-user-friends fa-fw"></span> All Delegations
             </a>
+            @endif
             @if($can_view_school_admin_index)
             <a class="dropdown-item" href="{{ route('schools.index') }}">
               <span class="fas fa-university fa-fw"></span> All Schools

--- a/resources/views/profiles/edit.blade.php
+++ b/resources/views/profiles/edit.blade.php
@@ -1,6 +1,22 @@
 @extends('layout')
 @section('header')
 	@include('nav')
+	@push('breadcrumbs')
+		@if($profile->user->school)
+			<li class="breadcrumb-item">
+				<a href="{{ route('schools.show', ['school' => $profile->user->school]) }}">
+					{{ $profile->user->school->display_name }}
+				</a>
+			</li>
+		@endif
+		<li class="breadcrumb-item">
+			<a href="{{ route('profiles.show', ['profile' => $profile]) }}">{{ $profile->name }}</a>
+		</li>
+		<li class="breadcrumb-item active" aria-current="page">
+			Edit {{ ucwords($section) }}
+		</li>
+	@endpush
+	@include('breadcrumbs')
 @stop
 @section('title', 'Edit ' . ucwords($section))
 @section('content')

--- a/resources/views/profiles/index.blade.php
+++ b/resources/views/profiles/index.blade.php
@@ -2,6 +2,12 @@
 @section('title', $search ? 'Search Results' : 'All Profiles')
 @section('header')
 	@include('nav')
+	@push('breadcrumbs')
+		<li class="breadcrumb-item active" aria-current="page">
+			@if(!empty($search)) Search Results @else All Profiles @endif
+		</li>
+	@endpush
+	@include('breadcrumbs')
 @stop
 @section('content')
 

--- a/resources/views/profiles/show.blade.php
+++ b/resources/views/profiles/show.blade.php
@@ -15,6 +15,19 @@
 @stop
 @section('header')
 	@include('nav')
+	@push('breadcrumbs')
+		@if($profile->user->school)
+			<li class="breadcrumb-item">
+				<a href="{{ route('schools.show', ['school' => $profile->user->school]) }}">
+					{{ $profile->user->school->display_name }}
+				</a>
+			</li>
+		@endif
+		<li class="breadcrumb-item active" aria-current="page">
+			{{ $profile->name }}
+		</li>
+	@endpush
+	@include('breadcrumbs')
 @stop
 @section('content')
 <div class="profile">

--- a/resources/views/profiles/table.blade.php
+++ b/resources/views/profiles/table.blade.php
@@ -2,6 +2,15 @@
 @section('title', 'All Profiles Table')
 @section('header')
 	@include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            Admin
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            All Profiles
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 <div class="container">

--- a/resources/views/schools/create.blade.php
+++ b/resources/views/schools/create.blade.php
@@ -1,7 +1,23 @@
 @extends('layout')
 @section('title', 'Add a New School')
 @section('header')
-  @include('nav')
+    @include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            Admin
+        </li>
+        <li class="breadcrumb-item">
+            @can('viewAdminIndex', App\School::class)
+                <a href="{{ route('schools.index') }}">All Schools</a>
+            @else
+                All Schools
+            @endcan
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            Add a New School
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 
 @section('content')

--- a/resources/views/schools/edit.blade.php
+++ b/resources/views/schools/edit.blade.php
@@ -1,7 +1,26 @@
 @extends('layout')
 @section('title', 'Edit Schools')
 @section('header')
-  @include('nav')
+    @include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            Admin
+        </li>
+        <li class="breadcrumb-item">
+            @can('viewAdminIndex', App\School::class)
+                <a href="{{ route('schools.index') }}">All Schools</a>
+            @else
+                All Schools
+            @endcan
+        </li>
+        <li class="breadcrumb-item active">
+            {{ $school->display_name }}
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            Edit
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 
 @section('content')

--- a/resources/views/schools/index.blade.php
+++ b/resources/views/schools/index.blade.php
@@ -2,6 +2,15 @@
 @section('title', 'All Schools Table')
 @section('header')
 	@include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            Admin
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            All Schools
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 <div class="container">

--- a/resources/views/schools/show.blade.php
+++ b/resources/views/schools/show.blade.php
@@ -2,6 +2,12 @@
 @section('title', "$school->display_name")
 @section('header')
 	@include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active" aria-current="page">
+            {{ $school->display_name }}
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 <div class="container">

--- a/resources/views/settings.blade.php
+++ b/resources/views/settings.blade.php
@@ -1,7 +1,16 @@
 @extends('layout')
 @section('title', 'Edit Settings')
 @section('header')
-  @include('nav')
+    @include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            Admin
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            Edit Site Settings
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 
 @section('content')

--- a/resources/views/students/about.blade.php
+++ b/resources/views/students/about.blade.php
@@ -9,7 +9,13 @@
 </style>
 @stop
 @section('header')
-	@include('nav')
+    @include('nav')
+    @push('breadcrumbs')
+		<li class="breadcrumb-item active" aria-current="page">
+			Student Research
+		</li>
+	@endpush
+	@include('breadcrumbs')
 @stop
 @section('content')
 

--- a/resources/views/students/edit.blade.php
+++ b/resources/views/students/edit.blade.php
@@ -2,6 +2,25 @@
 @section('title', 'Edit Student Research Application')
 @section('header')
 	@include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item">
+            <a href="{{ route('students.about') }}">Student Research</a>
+        </li>
+        <li class="breadcrumb-item active">
+            @can('viewAny', App\Student::class)
+                <a href="{{ route('students.index') }}">All Applications</a>
+            @else
+                Applications
+            @endcan
+        </li>
+        <li class="breadcrumb-item">
+            <a href="{{ route('students.show', ['student' => $student]) }}">{{ $student->full_name }}</a>
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            Edit
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 

--- a/resources/views/students/index.blade.php
+++ b/resources/views/students/index.blade.php
@@ -2,6 +2,15 @@
 @section('title', 'All Student Research Applications')
 @section('header')
 	@include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item">
+            <a href="{{ route('students.about') }}">Student Research</a>
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            All Applications
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 

--- a/resources/views/students/profile-students.blade.php
+++ b/resources/views/students/profile-students.blade.php
@@ -2,6 +2,22 @@
 @section('title', "Student Research Applications for {$profile->full_name}")
 @section('header')
 	@include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item">
+            <a href="{{ route('students.about') }}">Student Research</a>
+        </li>
+        <li class="breadcrumb-item">
+            @can('viewAny', App\Student::class)
+                <a href="{{ route('students.index') }}">All Applications</a>
+            @else
+                Applications
+            @endcan
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            Applications for {{ $profile->full_name }}
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 

--- a/resources/views/students/show.blade.php
+++ b/resources/views/students/show.blade.php
@@ -1,7 +1,23 @@
 @extends('layout')
 @section('title', "Student Research Application for {$student->full_name}")
 @section('header')
-	@include('nav')
+    @include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item">
+            <a href="{{ route('students.about') }}">Student Research</a>
+        </li>
+        <li class="breadcrumb-item active">
+            @can('viewAny', App\Student::class)
+                <a href="{{ route('students.index') }}">All Applications</a>
+            @else
+                Applications
+            @endcan
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            {{ $student->full_name }}
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 

--- a/resources/views/tags/create.blade.php
+++ b/resources/views/tags/create.blade.php
@@ -2,6 +2,20 @@
 @section('title', 'Create a new tag')
 @section('header')
     @include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            Admin
+        </li>
+        @can('viewAdminIndex', Spatie\Tags\Tag::class)
+            <li class="breadcrumb-item active">
+                <a href="{{ route('tags.table') }}">All Tags</a>
+            </li>
+        @endcan
+        <li class="breadcrumb-item active" aria-current="page">
+            Add Tags
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 

--- a/resources/views/tags/index.blade.php
+++ b/resources/views/tags/index.blade.php
@@ -2,6 +2,12 @@
 @section('title', 'All Tags')
 @section('header')
 	@include('nav')
+	@push('breadcrumbs')
+		<li class="breadcrumb-item active" aria-current="page">
+			All Tags
+		</li>
+	@endpush
+	@include('breadcrumbs')
 @stop
 @section('content')
 

--- a/resources/views/tags/table.blade.php
+++ b/resources/views/tags/table.blade.php
@@ -2,6 +2,15 @@
 @section('title', 'All Tags Table')
 @section('header')
     @include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            Admin
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            All Tags
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 

--- a/resources/views/users/bookmarks.blade.php
+++ b/resources/views/users/bookmarks.blade.php
@@ -2,6 +2,26 @@
 @section('title', 'User Bookmarks - ' . $user->display_name)
 @section('header')
     @include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            @can('viewAdminIndex', App\User::class)
+                <a href="{{ route('users.index') }}">All Users</a>
+            @else
+                Users
+            @endcan
+        </li>
+        <li class="breadcrumb-item active">
+            @can('view', $user)
+                <a href="{{ route('users.show', ['user' => $user]) }}">{{ $user->display_name }}</a>
+            @else
+                {{ $user->display_name }}
+            @endcan
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            Bookmarks
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 <div class="container">

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -1,7 +1,23 @@
 @extends('layout')
 @section('title', 'Add a New User')
 @section('header')
-  @include('nav')
+    @include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            Admin
+        </li>
+        <li class="breadcrumb-item active">
+            @can('viewAdminIndex', App\User::class)
+                <a href="{{ route('users.index') }}">All Users</a>
+            @else
+                Users
+            @endcan
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            Add a New User
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 
 @section('content')

--- a/resources/views/users/delegations/index.blade.php
+++ b/resources/views/users/delegations/index.blade.php
@@ -2,6 +2,15 @@
 @section('title', 'All Delegations Table')
 @section('header')
 	@include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            Admin
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            All Delegations
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 <div class="container">

--- a/resources/views/users/delegations/show.blade.php
+++ b/resources/views/users/delegations/show.blade.php
@@ -1,7 +1,27 @@
 @extends('layout')
 @section('title', "$user->display_name Delegations")
 @section('header')
-	@include('nav')
+    @include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            @can('viewAdminIndex', App\User::class)
+                <a href="{{ route('users.index') }}">All Users</a>
+            @else
+                Users
+            @endcan
+        </li>
+        <li class="breadcrumb-item active">
+            @can('view', $user)
+                <a href="{{ route('users.show', ['user' => $user]) }}">{{ $user->display_name }}</a>
+            @else
+                {{ $user->display_name }}
+            @endcan
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            Delegations
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 <div class="container">

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -2,6 +2,29 @@
 @section('title', 'Edit User - ' . $user->name)
 @section('header')
 	@include('nav')
+	@push('breadcrumbs')
+		<li class="breadcrumb-item active">
+			Admin
+		</li>
+		<li class="breadcrumb-item active">
+			@can('viewAdminIndex', App\User::class)
+				<a href="{{ route('users.index') }}">All Users</a>
+			@else
+				Users
+			@endcan
+		</li>
+		<li class="breadcrumb-item active">
+			@can('view', $user)
+				<a href="{{ route('users.show', ['user' => $user]) }}">{{ $user->display_name }}</a>
+			@else
+				{{ $user->display_name }}
+			@endcan
+		</li>
+		<li class="breadcrumb-item active" aria-current="page">
+			Edit
+		</li>
+	@endpush
+	@include('breadcrumbs')
 @stop
 @section('content')
 <div class="container">

--- a/resources/views/users/index.blade.php
+++ b/resources/views/users/index.blade.php
@@ -1,7 +1,16 @@
 @extends('layout')
 @section('title', 'All Users Table')
 @section('header')
-	@include('nav')
+    @include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            Admin
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            All Users
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 <div class="container">

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -4,7 +4,20 @@ $current_user = Auth::user();
 @extends('layout')
 @section('title', 'User Account - ' . $user->display_name)
 @section('header')
-  @include('nav')
+    @include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            @can('viewAdminIndex', App\User::class)
+                <a href="{{ route('users.index') }}">All Users</a>
+            @else
+                Users
+            @endcan
+        </li>
+        <li class="breadcrumb-item active" aria-current="page">
+            {{ $user->display_name }}
+        </li>
+    @endpush
+    @include('breadcrumbs')
 @stop
 @section('content')
 <div class="container">

--- a/tests/Feature/StudentTest.php
+++ b/tests/Feature/StudentTest.php
@@ -108,8 +108,11 @@ class StudentTest extends TestCase
         $this->followingRedirects()->get($unsubmit_route)
             ->assertStatus(200)
             ->assertSee('Student profile status updated');
-        
-        $this->assertDatabaseHas('students', array_merge($student->getAttributes(), ['status' => 'drafted']));
+
+        $this->assertDatabaseHas('students', [
+            'id' => $student->id,
+            'status' => 'drafted',
+        ]);
 
         $this->loginAsUserWithRole('site_admin');
 


### PR DESCRIPTION
Adds breadcrumbs to nested pages for easier navigation. On profile pages, it shows the user/profile's school as the parent page.

<img width="1153" alt="Screen Shot 2022-08-22 at 5 41 59 PM" src="https://user-images.githubusercontent.com/11369963/186031634-6a474a90-dd29-4b7e-9975-4edb00136eab.png">

<img width="879" alt="Screen Shot 2022-08-22 at 5 42 50 PM" src="https://user-images.githubusercontent.com/11369963/186031675-6a08f16a-ff28-4d4b-8751-526398a4c8a9.png">


