### PR TITLE
Fixes typo in error message when adding a user/profile

### DIFF
--- a/resources/views/errors/list.blade.php
+++ b/resources/views/errors/list.blade.php
@@ -2,7 +2,7 @@
 <div class="row">
 	<div class="alert alert-danger alert-dismissable col-sm-offset-2 col-sm-9" role="alert">
 		<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-		<p><strong>The are some errors. Please correct them and try again.</strong></p>
+		<p><strong>There are some errors. Please correct them and try again.</strong></p>
 		@foreach ($errors->all() as $error)
 			{{ $error }}<br>
 		@endforeach


### PR DESCRIPTION
During my meeting with Brandon Brown, we noticed this:
<img width="505" alt="Screen Shot 2022-09-20 at 4 22 30 PM" src="https://user-images.githubusercontent.com/5490820/191772266-dd60279c-cefc-40da-9d5c-21dc067ba8ff.png">
