### PR TITLE
Accepting students wording

### DIFF
--- a/app/Http/Livewire/AcceptingStudentsToggle.php
+++ b/app/Http/Livewire/AcceptingStudentsToggle.php
@@ -27,13 +27,16 @@ class AcceptingStudentsToggle extends Component
         /** @var \App\ProfileData fresh copy of the profile info */
         $info = $this->profile->information()->first();
 
-        $updated = $info->updateData(['not_accepting_students' => $toggled_on ? '1' : '0']);
+        $updated = $info->updateData([
+            'show_not_accepting_students' => $toggled_on ? '1' : '0',
+            'not_accepting_students' => $toggled_on ? '1' : '0',
+        ]);
 
         if (!$updated) {
             $this->emit('alert', "Not saved. There was a problem changing that setting", 'danger');
         }
 
-        $this->emit('alert', "<strong>Saved.</strong><br> Profile for {$this->profile->full_name} marked as " . ($toggled_on ? "not" : "") . " accepting students", 'success');
+        $this->emit('alert', "<strong>Saved.</strong><br> Profile for {$this->profile->full_name} marked as " . ($toggled_on ? "not" : "") . " accepting undergraduate students", 'success');
     }
 
     public function render()

--- a/resources/views/livewire/accepting-students-toggle.blade.php
+++ b/resources/views/livewire/accepting-students-toggle.blade.php
@@ -5,8 +5,8 @@
             type="checkbox"
             id="notAcceptingStudentsCheckbox"
         >
-        <label class="form-check-label font-weight-bold text-primary clickable" for="notAcceptingStudentsCheckbox">
-            <i class="fas fa-user-slash fa-fw"></i> I'm not accepting students
+        <label class="d-inline form-check-label font-weight-bold text-primary clickable" for="notAcceptingStudentsCheckbox">
+            <i class="fas fa-user-slash fa-fw"></i> I'm not accepting undergraduate students
         </label>
     </div>
     @include('livewire.partials._loading-fixed', ['loading_target' => 'not_accepting_students'])

--- a/resources/views/livewire/accepting-students-toggle.blade.php
+++ b/resources/views/livewire/accepting-students-toggle.blade.php
@@ -1,11 +1,12 @@
 <form>
-    <div class="checkbox-group">
+    <div class="form-check form-check-inline align-items-baseline m-0">
         <input
             wire:model="not_accepting_students"
             type="checkbox"
             id="notAcceptingStudentsCheckbox"
+            class="form-check-input"
         >
-        <label class="d-inline form-check-label font-weight-bold text-primary clickable" for="notAcceptingStudentsCheckbox">
+        <label class="form-check-label font-weight-bold text-primary clickable" for="notAcceptingStudentsCheckbox">
             <i class="fas fa-user-slash fa-fw"></i> I'm not accepting undergraduate students
         </label>
     </div>

--- a/resources/views/profiles/edit/information.blade.php
+++ b/resources/views/profiles/edit/information.blade.php
@@ -172,20 +172,106 @@
 					</label>
 				</div>
 			</div>
-			<div class="form-group row">
-				<div class="col col-4">
-					<label for="visibility">Not Accepting Students</label><br>
-					<label class="switch pull-left">
-						<input type="hidden" name="data[{{$info->id}}][data][not_accepting_students]" id="data[{{$info->id}}][data][not_accepting_students]" value="0">
-						<input type="checkbox" name="data[{{$info->id}}][data][not_accepting_students]" id="data[{{$info->id}}][data][not_accepting_students]" value="1" @if($info->not_accepting_students) checked @endif>
-						<span class="slider round"></span>
-					</label>
+			<fieldset class="form-group row my-3 py-4 border-top">
+				<div class="col col-12 col-xl-7">
+					<div class="form-group form-check p-0">
+						<input type="hidden" name="data[{{$info->id}}][data][show_accepting_students]" value="0">
+						<input
+							type="checkbox"
+							name="data[{{$info->id}}][data][show_accepting_students]"
+							id="data[{{$info->id}}][data][show_accepting_students]"
+							@checked(old('data.show_accepting_students', $info->show_accepting_students))
+							value="1"
+							data-toggle="show"
+							data-toggle-target="#accepting_student_types"
+						>
+						<label class="form-check-label" for="data[{{$info->id}}][data][show_accepting_students]">Show that I'm accepting students</label>
+					</div>
+					<div
+						id="accepting_student_types"
+						class="border-left ml-3"
+						@style([
+							'display: none' => !old('data.show_accepting_students', $info->show_accepting_students)
+						])
+					>
+						<div class="form-group form-check">
+							<input type="hidden" name="data[{{$info->id}}][data][accepting_students]" value="0">
+							<input
+								type="checkbox"
+								name="data[{{$info->id}}][data][accepting_students]"
+								id="data[{{$info->id}}][data][accepting_students]"
+								@checked(old('data.accepting_students', $info->accepting_students))
+								value="1"
+							>
+							<label class="form-check-label" for="data[{{$info->id}}][data][accepting_students]">Accepting undergrad students</label>
+						</div>
+						<div class="form-group form-check">
+							<input type="hidden" name="data[{{$info->id}}][data][accepting_grad_students]" value="0">
+							<input
+								type="checkbox"
+								name="data[{{$info->id}}][data][accepting_grad_students]"
+								id="data[{{$info->id}}][data][accepting_grad_students]"
+								@checked(old('data.accepting_grad_students', $info->accepting_grad_students))
+								value="1"
+							>
+							<label class="form-check-label" for="data[{{$info->id}}][data][accepting_grad_students]">Accepting grad students</label>
+						</div>
+					</div>
 				</div>
-				<div class="col col-8">
-					<br>
-					<p>Turning this on will show a standard note on your profile that you're not currently accepting students.</p>
+				<div class="col col-8 col-xl-5">
+					<p class="text-muted">This will show a standard note on your profile that you're currently accepting students of the specified type(s).</p>
 				</div>
-			</div>
+			</fieldset>
+			<fieldset class="form-group row my-3 py-4 border-top">
+				<div class="col col-12 col-xl-7">
+					<div class="form-group form-check p-0">
+						<input type="hidden" name="data[{{$info->id}}][data][show_not_accepting_students]" value="0">
+						<input
+							type="checkbox"
+							name="data[{{$info->id}}][data][show_not_accepting_students]"
+							id="data[{{$info->id}}][data][show_not_accepting_students]"
+							@checked(old('data.show_not_accepting_students', $info->show_not_accepting_students))
+							value="1"
+							data-toggle="show"
+							data-toggle-target="#not_accepting_student_types"
+						>
+						<label class="form-check-label" for="data[{{$info->id}}][data][show_not_accepting_students]">Show that I'm not accepting students</label>
+					</div>
+					<div
+						id="not_accepting_student_types"
+						class="border-left ml-3"
+						@style([
+							'display: none' => !old('data.show_not_accepting_students', $info->show_not_accepting_students)
+						])
+					>
+						<div class="form-group form-check">
+							<input type="hidden" name="data[{{$info->id}}][data][not_accepting_students]" value="0">
+							<input
+								type="checkbox"
+								name="data[{{$info->id}}][data][not_accepting_students]"
+								id="data[{{$info->id}}][data][not_accepting_students]"
+								@checked(old('data.not_accepting_students', $info->not_accepting_students))
+								value="1"
+							>
+							<label class="form-check-label" for="data[{{$info->id}}][data][not_accepting_students]">Not accepting undergrad students</label>
+						</div>
+						<div class="form-group form-check">
+							<input type="hidden" name="data[{{$info->id}}][data][not_accepting_grad_students]" value="0">
+							<input
+								type="checkbox"
+								name="data[{{$info->id}}][data][not_accepting_grad_students]"
+								id="data[{{$info->id}}][data][not_accepting_grad_students]"
+								@checked(old('data.not_accepting_grad_students', $info->not_accepting_grad_students))
+								value="1"
+							>
+							<label class="form-check-label" for="data[{{$info->id}}][data][not_accepting_grad_students]">Not accepting grad students</label>
+						</div>
+					</div>
+				</div>
+				<div class="col col-8 col-xl-5">
+					<p class="text-muted">This will show a standard note on your profile that you're <em>not</em> currently accepting students of the specified type(s).</p>
+				</div>
+			</fieldset>
 			<div class="form-group row">
 				<div class="col col-4">
 					<label for="visibility">Profile Visible</label><br>

--- a/resources/views/profiles/edit/information.blade.php
+++ b/resources/views/profiles/edit/information.blade.php
@@ -138,41 +138,65 @@
 				<label for="data[{{$info->id}}][data][orc_id]">ORCID</label>
 				<input type="text" class="form-control" name="data[{{$info->id}}][data][orc_id]" id="data[{{$info->id}}][data][orc_id]" value="{{$info->orc_id}}"  onkeyup="javascript:$(this).val($(this).val().replace('https://orcid.org/', '').replace('http://orcid.org/', ''));" pattern="^[0-9]{4}-[0-9]{4}-[0-9]{4}-[0-9]{3}[0-9X]$"/>
 			</div>
-			<div class="form-group row">
-				<div class="col col-4">
-					<label for="data[{{$info->id}}][data][orc_id_managed]">Auto Update Publications</label><br>
-					<label class="switch">
-					  <input type="hidden" name="data[{{$info->id}}][data][orc_id_managed]" id="data[{{$info->id}}][data][orc_id_managed]" value="0">
-					  <input type="checkbox" name="data[{{$info->id}}][data][orc_id_managed]" id="data[{{$info->id}}][data][orc_id_managed]" value="1" @if($info->orc_id_managed) checked @endif>
-					  <span class="slider round"></span>
-					</label>
+			<fieldset id="orcid_managed" class="form-group row my-3 py-4">
+				<div class="col col-12 col-xl-7">
+					<div class="form-group form-check p-0">
+						<input type="hidden" name="data[{{$info->id}}][data][orc_id_managed]" value="0">
+						<input
+							type="checkbox"
+							name="data[{{$info->id}}][data][orc_id_managed]"
+							id="data[{{$info->id}}][data][orc_id_managed]"
+							@checked(old("data.{$info->id}.data.orc_id_managed", $info->orc_id_managed))
+							value="1"
+						>
+						<label class="form-check-label" for="data[{{$info->id}}][data][orc_id_managed]">Auto-update Publications</label>
+					</div>
 				</div>
-				<div class="col col-8">
-					<br>
-					<p>Refresh all publications via ORCID. All previous publications will be removed and fresh data will be pulled in at regular intervals.</p>
+				<div class="col col-12 col-xl-5">
+					<p class="text-muted">Refresh all publications via ORCID. All previous publications will be removed and fresh data will be pulled in at regular intervals. Keep unchecked to manually edit your publications.</p>
 				</div>
-			</div>
-			<div class="form-group row">
-				<div class="col col-4">
-					<label for="visibility">Fancy Header</label><br>
-					<label class="switch pull-left">
-						<input type="hidden" name="data[{{$info->id}}][data][fancy_header]" id="data[{{$info->id}}][data][fancy_header]" value="0">
-						<input type="checkbox" name="data[{{$info->id}}][data][fancy_header]" id="data[{{$info->id}}][data][fancy_header]" value="1" @if($info->fancy_header) checked @endif>
-						<span class="slider round"></span>
-					</label>
+			</fieldset>
+			<fieldset id="fancy_header" class="form-group row my-3 py-4 border-top">
+				<div class="col col-12 col-xl-7">
+					<div class="form-group form-check p-0">
+						<input type="hidden" name="data[{{$info->id}}][data][fancy_header]" value="0">
+						<input
+							type="checkbox"
+							name="data[{{$info->id}}][data][fancy_header]"
+							id="data[{{$info->id}}][data][fancy_header]"
+							@checked(old("data.{$info->id}.data.fancy_header", $info->fancy_header))
+							value="1"
+							data-toggle="show"
+							data-toggle-target="#fancy_header_options"
+						>
+						<label class="form-check-label" for="data[{{$info->id}}][data][fancy_header]">Fancy Header</label>
+					</div>
+					{{-- reset sub-options if main option is unchecked --}}
+					<input type="hidden" name="data[{{$info->id}}][data][fancy_header_right]" value="0">
+					<div
+						id="fancy_header_options"
+						class="border-left ml-3"
+						@style([
+							'display: none' => !old('data.show_accepting_students', $info->show_accepting_students)
+						])
+					>
+						<div class="form-group form-check">
+							<input
+								type="checkbox"
+								name="data[{{$info->id}}][data][fancy_header_right]"
+								id="data[{{$info->id}}][data][fancy_header_right]"
+								@checked(old("data.{$info->id}.data.fancy_header_right", $info->fancy_header_right))
+								value="1"
+							>
+							<label class="form-check-label" for="data[{{$info->id}}][data][fancy_header_right]">Align Header Right</label>
+						</div>
+					</div>
 				</div>
-				<div class="col col-8">
-					<br>
-					<p>This will use a full-width header style - please make sure uploaded image is of sufficient quality!</p>
-					<label for="visibility">Align Header Right</label><br>
-					<label class="switch pull-left">
-						<input type="hidden" name="data[{{$info->id}}][data][fancy_header_right]" id="data[{{$info->id}}][data][fancy_header_right]" value="0">
-						<input type="checkbox" name="data[{{$info->id}}][data][fancy_header_right]" id="data[{{$info->id}}][data][fancy_header_right]" value="1" @if($info->fancy_header_right) checked @endif>
-						<span class="slider round"></span>
-					</label>
+				<div class="col col-12 col-xl-5">
+					<p class="text-muted">This will use a full-width header style - please make sure uploaded banner image is of sufficient quality!</p>
 				</div>
-			</div>
-			<fieldset class="form-group row my-3 py-4 border-top">
+			</fieldset>
+			<fieldset id="show_accepting" class="form-group row my-3 py-4 border-top">
 				<div class="col col-12 col-xl-7">
 					<div class="form-group form-check p-0">
 						<input type="hidden" name="data[{{$info->id}}][data][show_accepting_students]" value="0">
@@ -180,49 +204,50 @@
 							type="checkbox"
 							name="data[{{$info->id}}][data][show_accepting_students]"
 							id="data[{{$info->id}}][data][show_accepting_students]"
-							@checked(old('data.show_accepting_students', $info->show_accepting_students))
+							@checked(old("data.{$info->id}.data.show_accepting_students", $info->show_accepting_students))
 							value="1"
 							data-toggle="show"
-							data-toggle-target="#accepting_student_types"
+							data-toggle-target="#accepting_student_options"
 						>
 						<label class="form-check-label" for="data[{{$info->id}}][data][show_accepting_students]">Show that I'm accepting students</label>
 					</div>
+					{{-- reset sub-options if main option is unchecked --}}
+					<input type="hidden" name="data[{{$info->id}}][data][accepting_students]" value="0">
+					<input type="hidden" name="data[{{$info->id}}][data][accepting_grad_students]" value="0">
 					<div
-						id="accepting_student_types"
+						id="accepting_student_options"
 						class="border-left ml-3"
 						@style([
 							'display: none' => !old('data.show_accepting_students', $info->show_accepting_students)
 						])
 					>
 						<div class="form-group form-check">
-							<input type="hidden" name="data[{{$info->id}}][data][accepting_students]" value="0">
 							<input
 								type="checkbox"
 								name="data[{{$info->id}}][data][accepting_students]"
 								id="data[{{$info->id}}][data][accepting_students]"
-								@checked(old('data.accepting_students', $info->accepting_students))
+								@checked(old("data.{$info->id}.data.accepting_students", $info->accepting_students))
 								value="1"
 							>
 							<label class="form-check-label" for="data[{{$info->id}}][data][accepting_students]">Accepting undergrad students</label>
 						</div>
 						<div class="form-group form-check">
-							<input type="hidden" name="data[{{$info->id}}][data][accepting_grad_students]" value="0">
 							<input
 								type="checkbox"
 								name="data[{{$info->id}}][data][accepting_grad_students]"
 								id="data[{{$info->id}}][data][accepting_grad_students]"
-								@checked(old('data.accepting_grad_students', $info->accepting_grad_students))
+								@checked(old("data.{$info->id}.data.accepting_grad_students", $info->accepting_grad_students))
 								value="1"
 							>
 							<label class="form-check-label" for="data[{{$info->id}}][data][accepting_grad_students]">Accepting grad students</label>
 						</div>
 					</div>
 				</div>
-				<div class="col col-8 col-xl-5">
+				<div class="col col-12 col-xl-5">
 					<p class="text-muted">This will show a standard note on your profile that you're currently accepting students of the specified type(s).</p>
 				</div>
 			</fieldset>
-			<fieldset class="form-group row my-3 py-4 border-top">
+			<fieldset id="show_not_accepting" class="form-group row my-3 py-4 border-top">
 				<div class="col col-12 col-xl-7">
 					<div class="form-group form-check p-0">
 						<input type="hidden" name="data[{{$info->id}}][data][show_not_accepting_students]" value="0">
@@ -230,62 +255,67 @@
 							type="checkbox"
 							name="data[{{$info->id}}][data][show_not_accepting_students]"
 							id="data[{{$info->id}}][data][show_not_accepting_students]"
-							@checked(old('data.show_not_accepting_students', $info->show_not_accepting_students))
+							@checked(old("data.{$info->id}.data.show_not_accepting_students", $info->show_not_accepting_students))
 							value="1"
 							data-toggle="show"
-							data-toggle-target="#not_accepting_student_types"
+							data-toggle-target="#not_accepting_student_options"
 						>
 						<label class="form-check-label" for="data[{{$info->id}}][data][show_not_accepting_students]">Show that I'm not accepting students</label>
 					</div>
+					{{-- reset sub-options if main option is unchecked --}}
+					<input type="hidden" name="data[{{$info->id}}][data][not_accepting_students]" value="0">
+					<input type="hidden" name="data[{{$info->id}}][data][not_accepting_grad_students]" value="0">
 					<div
-						id="not_accepting_student_types"
+						id="not_accepting_student_options"
 						class="border-left ml-3"
 						@style([
 							'display: none' => !old('data.show_not_accepting_students', $info->show_not_accepting_students)
 						])
 					>
 						<div class="form-group form-check">
-							<input type="hidden" name="data[{{$info->id}}][data][not_accepting_students]" value="0">
 							<input
 								type="checkbox"
 								name="data[{{$info->id}}][data][not_accepting_students]"
 								id="data[{{$info->id}}][data][not_accepting_students]"
-								@checked(old('data.not_accepting_students', $info->not_accepting_students))
+								@checked(old("data.{$info->id}.data.not_accepting_students", $info->not_accepting_students))
 								value="1"
 							>
 							<label class="form-check-label" for="data[{{$info->id}}][data][not_accepting_students]">Not accepting undergrad students</label>
 						</div>
 						<div class="form-group form-check">
-							<input type="hidden" name="data[{{$info->id}}][data][not_accepting_grad_students]" value="0">
 							<input
 								type="checkbox"
 								name="data[{{$info->id}}][data][not_accepting_grad_students]"
 								id="data[{{$info->id}}][data][not_accepting_grad_students]"
-								@checked(old('data.not_accepting_grad_students', $info->not_accepting_grad_students))
+								@checked(old("data.{$info->id}.data.not_accepting_grad_students", $info->not_accepting_grad_students))
 								value="1"
 							>
 							<label class="form-check-label" for="data[{{$info->id}}][data][not_accepting_grad_students]">Not accepting grad students</label>
 						</div>
 					</div>
 				</div>
-				<div class="col col-8 col-xl-5">
+				<div class="col col-12 col-xl-5">
 					<p class="text-muted">This will show a standard note on your profile that you're <em>not</em> currently accepting students of the specified type(s).</p>
 				</div>
 			</fieldset>
-			<div class="form-group row">
-				<div class="col col-4">
-					<label for="visibility">Profile Visible</label><br>
-					<label class="switch pull-left">
-						<input type="hidden" name="public" id="public" value="0">
-						<input type="checkbox" name="public" id="public" value="1" @if($profile->public) checked @endif>
-						<span class="slider round"></span>
-					</label>
+			<fieldset class="form-group row my-3 py-4 border-top border-bottom">
+				<div class="col col-12 col-xl-7">
+					<div class="form-group form-check p-0">
+						<input type="hidden" name="public" value="0">
+						<input
+							type="checkbox"
+							name="public"
+							id="public"
+							@checked(old('public', $profile->public))
+							value="1"
+						>
+						<label class="form-check-label" for="public">Profile is visible</label>
+					</div>
 				</div>
-				<div class="col col-8">
-					<br>
-					<p>Make profile viewable and searchable by website visitors. (If turned off, it will still be accessible via the public API and to site administrators.</p>
+				<div class="col col-12 col-xl-5">
+					<p class="text-muted">Make profile viewable and searchable by website visitors. (If turned off, it will still be accessible via the public API and to site administrators.)</p>
 				</div>
-			</div>
+			</fieldset>
 			{!! Form::submit('Save', array('class' => 'btn btn-primary edit-button')) !!}
 			<a href="{{ $profile->url }}" class='btn btn-light edit-button'>Cancel</a>
 			{!! Form::close() !!}

--- a/resources/views/profiles/show.blade.php
+++ b/resources/views/profiles/show.blade.php
@@ -83,7 +83,16 @@
 									<a href="{{$information->$url_key}}" target="_blank">@if($information->$url_name){{$information->$url_name}}@else{{"Website"}}@endif</a><br />@endif
 								@endforeach
 								@if($information->orc_id)<i class="fab fa-fw fa-orcid" aria-hidden="true"></i> <a href="https://orcid.org/{{$information->orc_id}}" target="_blank">ORCID</a><br />@endif
-								@if($information->not_accepting_students)<p class="mt-3 mb-0 text-muted"><small><i class="fas fa-fw fa-user-slash" aria-hidden="true"></i> Not currently accepting students</small></p>@endif
+								@if($information->show_accepting_students || $information->show_not_accepting_students)
+								<p class="mt-3 mb-0">
+									@if($information->show_accepting_students)
+										<p class="m-0"><small><i class="fas fa-fw fa-user-graduate" aria-hidden="true"></i> Currently accepting {{ collect(['undergraduate' => $information->accepting_students, 'graduate' => $information->accepting_grad_students])->filter()->keys()->implode(' and ') }} students</small></p>
+									@endif
+									@if($information->show_not_accepting_students)
+										<p class="m-0 text-muted"><small><i class="fas fa-fw fa-user-slash" aria-hidden="true"></i> Not currently accepting {{ collect(['undergraduate' => $information->not_accepting_students, 'graduate' => $information->not_accepting_grad_students])->filter()->keys()->implode(' or ') }} students</small></p>
+									@endif
+								</p>
+								@endif
 							</div>
 						@if(!$profile->tags->isEmpty() || $editable)
 						<div class="protocol-tags">

--- a/resources/views/students/profile-students.blade.php
+++ b/resources/views/students/profile-students.blade.php
@@ -54,7 +54,7 @@
                         aria-labelledby="notAcceptingStudentsButton"
                     >
                         <p>
-                            <small class="form-text text-muted">Checking the box below will show a standard note on your profile that you're not currently accepting students.</small>
+                            <small class="form-text text-muted">Checking the box below will show a standard note on your profile that you're not currently accepting undergraduate students for research.</small>
                         </p>
                         <livewire:accepting-students-toggle :profile="$profile">
                     </div>

--- a/resources/views/students/profile-students.blade.php
+++ b/resources/views/students/profile-students.blade.php
@@ -57,6 +57,9 @@
                             <small class="form-text text-muted">Checking the box below will show a standard note on your profile that you're not currently accepting undergraduate students for research.</small>
                         </p>
                         <livewire:accepting-students-toggle :profile="$profile">
+                        <p class="text-right mt-3 mb-0">
+                            <small><a href="{{ route('profiles.edit', ['profile' => $profile->slug, 'section' => 'information']) }}#show_not_accepting">Additional options <i class="fas fa-caret-right"></i></a></small>
+                        </p>
                     </div>
                 </span>
                 @can('viewDelegations', $profile->user)


### PR DESCRIPTION
This improves the existing "not accepting students" profile option to add more clarity. Users can now specify the type of student (undergraduate vs graduate).

In addition, this adds a new options to show that they _are_ accepting students, also with the ability to specify type.

Finally, it changes the profile edit information options from toggle switches to checkboxes for clarity and UX consistency (In standard UX, toggle switches are meant to take immediate effect, whereas checkboxes take effect only after saving.)

<img width="801" alt="Screenshot 2023-09-08 at 2 42 53 PM" src="https://github.com/utdal/profiles/assets/11369963/3017dc19-bf04-49b5-9471-57ab14d16c4f">

<img width="459" alt="Screenshot 2023-09-08 at 2 43 15 PM" src="https://github.com/utdal/profiles/assets/11369963/d24cbfcc-b54e-4683-b1c1-aa1f9820b309">
