### PR TITLE
🐛 Adds 'reindex' action on sort to sortable publications html container

### DIFF
--- a/public/js/app.js
+++ b/public/js/app.js
@@ -144,6 +144,9 @@ var profiles = function ($, undefined) {
    * @return {void}
    */
   var on_list_updated = function on_list_updated(el, actions) {
+    if (typeof actions !== 'string') {
+      return;
+    }
     var _iterator4 = _createForOfIteratorHelper(actions.split(',').map(function (i) {
         return i.trim();
       })),
@@ -578,7 +581,8 @@ $(function () {
       scrollSpeed: 50,
       ghostClass: 'sortable-ghost',
       onUpdate: function onUpdate(evt) {
-        return profiles.on_list_updated(evt.target, evt.target.dataset.onsort);
+        var _evt$target$dataset$o;
+        return profiles.on_list_updated(evt.target, (_evt$target$dataset$o = evt.target.dataset.onsort) !== null && _evt$target$dataset$o !== void 0 ? _evt$target$dataset$o : '');
       }
     });
   }

--- a/resources/assets/js/app.js
+++ b/resources/assets/js/app.js
@@ -107,6 +107,7 @@ var profiles = (function ($, undefined) {
      * @return {void}
      */
     const on_list_updated = (el, actions) => {
+        if (typeof actions !== 'string') { return; }
         for (const action of actions.split(',').map(i => i.trim())) {
             if (action === 'reindex') {
                 reindex_sorted_list(el.children);
@@ -518,7 +519,7 @@ $(function() {
             scroll: true,
             scrollSpeed: 50,
             ghostClass: 'sortable-ghost',
-            onUpdate: (evt) => profiles.on_list_updated(evt.target, evt.target.dataset.onsort),
+            onUpdate: (evt) => profiles.on_list_updated(evt.target, evt.target.dataset.onsort ?? ''),
         });
     }
 

--- a/resources/views/profiles/edit/layout.blade.php
+++ b/resources/views/profiles/edit/layout.blade.php
@@ -8,7 +8,7 @@
 @include('profiles.edit._insert_button', ['type' => 'prepend'])
 <div class="row mb-4 lower-border"></div>
 
-<div class="sortable" data-onsort="reindex" data-next-row-id="-1">
+<div class="sortable" data-next-row-id="-1">
 
     @yield('form')
 

--- a/resources/views/profiles/edit/layout.blade.php
+++ b/resources/views/profiles/edit/layout.blade.php
@@ -8,7 +8,7 @@
 @include('profiles.edit._insert_button', ['type' => 'prepend'])
 <div class="row mb-4 lower-border"></div>
 
-<div class="sortable" data-next-row-id="-1">
+<div class="sortable" data-onsort="reindex" data-next-row-id="-1">
 
     @yield('form')
 


### PR DESCRIPTION
Fixes bug in issue #141. 

Used git bisect to find commit and diagnose issue that causes the publications rows rearranging feature to break in publications edit page:
```
fbd8492e44b7d345f84669d56a9bbf17371d8196 is the first bad commit - Custom student questions (#122).
```