### PR TITLE
Adds tag edit feature to tags index

### DIFF
--- a/app/Http/Controllers/TagsController.php
+++ b/app/Http/Controllers/TagsController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Cache;
 use Illuminate\View\View;
 use Spatie\Tags\Tag;
 use App\Http\Requests\TagsUpdateRequest;
+use App\Http\Requests\TagUpdateRequest;
 use Illuminate\Http\JsonResponse;
 
 class TagsController extends Controller
@@ -27,6 +28,12 @@ class TagsController extends Controller
             'create',
             'store',
         ]);
+
+        $this->middleware('can:update,tag,'.Tag::class)->only([
+            'editTag',
+            'updateTag',
+        ]);
+
     }
 
     /**
@@ -109,5 +116,25 @@ class TagsController extends Controller
         }
 
         return back()->with('flash_message', $message);
+    }
+
+    /**
+     * Edit a tag record.
+     */
+    public function editTag(Tag $tag)
+    {
+        return view('tags.edit', compact('tag'));
+    }
+
+    /**
+     * Update a single tag record.
+     */
+    public function updateTag(Tag $tag, TagUpdateRequest $request) 
+    {
+        $tag->update($request->all());
+
+        return redirect()
+                ->route('tags.table')
+                ->with('flash_message', 'The tag has been updated.');
     }
 }

--- a/app/Http/Requests/TagUpdateRequest.php
+++ b/app/Http/Requests/TagUpdateRequest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class TagUpdateRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        $locale = app()->getLocale();
+
+        return [
+           'type' => 'required',
+           'name' => [
+                        'required',
+                        'string',
+                        'max:100',
+                        Rule::unique('tags', 'name->'.$locale)
+                                ->where('type', $this->input('type'))
+                                ->ignore($this->input('id'))
+                    ],
+        ];
+    }
+
+    public function messages()
+    {
+        return [
+            'name.required' => 'The tag name is required.',
+            'name.unique' => 'The tag name provided already exists.',
+            'name.max' => 'The tag name provided exceeds maximum length of 100 characters.',
+        ]; 
+    }
+
+}

--- a/app/Policies/TagPolicy.php
+++ b/app/Policies/TagPolicy.php
@@ -59,6 +59,18 @@ class TagPolicy
     }
 
     /**
+     * Determine whether the user can update the tag.
+     *
+     * @param  \App\User  $user
+     * @param  \Spatie\Tags\Tag  $tag
+     * @return mixed
+     */
+    public function updateTag(User $user)
+    {
+        return false;
+    }
+
+    /**
      * Determine whether the user can delete the tag.
      *
      * @param  \App\User  $user

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -5,7 +5,6 @@ namespace App\Providers;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\App;
-use \Spatie\Tags\Tag;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -28,7 +27,6 @@ class RouteServiceProvider extends ServiceProvider
         //
 
         parent::boot();
-       // Route::bind('tag', fn($tag) => Tag::findFromStringOfAnyType($tag)->first());
     }
 
     /**

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
 use Illuminate\Support\Facades\App;
+use \Spatie\Tags\Tag;
 
 class RouteServiceProvider extends ServiceProvider
 {
@@ -27,6 +28,7 @@ class RouteServiceProvider extends ServiceProvider
         //
 
         parent::boot();
+       // Route::bind('tag', fn($tag) => Tag::findFromStringOfAnyType($tag)->first());
     }
 
     /**

--- a/resources/views/livewire/tags-table.blade.php
+++ b/resources/views/livewire/tags-table.blade.php
@@ -43,7 +43,7 @@
                 @include('livewire.partials._th-sortable', ['title' => 'Type', 'field' => 'type'])
                 @include('livewire.partials._th-sortable', ['title' => 'Created', 'field' => 'created_at'])
                 @include('livewire.partials._th-sortable', ['title' => 'Updated', 'field' => 'updated_at'])
-                <th>Actions</th>
+                <th colspan=2 >Actions</th>
             </tr>
         </thead>
         <tbody>
@@ -55,6 +55,13 @@
                 <td>{{ $tag->type }}</td>
                 <td>{{ $tag->created_at->toFormattedDateString() }}</td>
                 <td>{{ $tag->updated_at->toFormattedDateString() }}</td>
+                <td>
+                    @can('updateTag', Spatie\Tags\Tag::class)
+                        <a href="{{ route('tags.editTag', ['tag' => $tag ]) }}" title="Edit" role="button" title="edit" class="">
+                            <i class="far fa-edit"></i><span class="sr-only">Edit</span>
+                        </a>
+                    @endcan
+                </td>
                 <td>
                     <a onclick="confirm('Are you sure you want to remove the {{ $tag->slug }} tag?') || event.stopImmediatePropagation()" wire:click="destroy({{ $tag->id }})" role="button" title="delete">
                         <i class="far fa-trash-alt"></i><span class="sr-only">Trash</span>

--- a/resources/views/tags/edit.blade.php
+++ b/resources/views/tags/edit.blade.php
@@ -24,39 +24,25 @@
 
     @include('errors/has')
 
-    @if (Session::has('admin'))
-		<div class="alert alert-success alert-dismissable" role="alert">
-			<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-			{{ session('admin') }}
-		</div>
-	@endif
-
-	@if (Session::has('editor'))
-		<div class="alert alert-success alert-dismissable" role="alert">
-			<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
-			{{ session('editor') }}
-		</div>
-	@endif
-
     {!! Form::model($tag, ['method' => 'PATCH','route' => ['tags.updateTag', $tag], 'class' => 'form-horizontal' ]) !!}
 
-    <div class="form-group {{ ($errors->has('name') ?  'has-error' : '') }}">
-        {!! Form::label('name', 'Tag name(s)', ['class' => 'col-sm-2 control-label']) !!}
-        <div class="col-sm-9">
-            <span class="text-danger">{!! $errors->first('name') !!}</span>
-            {!! Form::text('name', null, ['class' => 'form-control']) !!}
+        <div class="form-group {{ ($errors->has('name') ?  'has-error' : '') }}">
+            {!! Form::label('name', 'Tag name(s)', ['class' => 'col-sm-2 control-label']) !!}
+            <div class="col-sm-9">
+                <span class="text-danger">{!! $errors->first('name') !!}</span>
+                {!! Form::text('name', null, ['class' => 'form-control']) !!}
+            </div>
+            <div class="col-sm-9">
+                <span class="text-danger">{!! $errors->first('type') !!}</span>
+                {!! Form::text('type', null, ['class' => 'form-control', 'readonly']) !!}
+            </div>
         </div>
-        <div class="col-sm-9">
-            <span class="text-danger">{!! $errors->first('type') !!}</span>
-            {!! Form::text('type', null, ['class' => 'form-control', 'readonly']) !!}
-        </div>
-    </div>
 
-	<!-- Submit Button -->
+        <!-- Submit Button -->
         <div class="col-sm-9">
             <a href="{{ route('tags.table') }}" class='btn btn-light'>Cancel</a>
             {!! Form::submit('Update Tag', ['class' => 'btn btn-primary']) !!}
-		</div>
-	{!! Form::close() !!}
+        </div>
+    {!! Form::close() !!}
 </div>
 @stop

--- a/resources/views/tags/edit.blade.php
+++ b/resources/views/tags/edit.blade.php
@@ -1,0 +1,62 @@
+@extends('layout')
+@section('title', 'Edit tag - $tag->name')
+@section('header')
+    @include('nav')
+    @push('breadcrumbs')
+        <li class="breadcrumb-item active">
+            Admin
+        </li>
+        @can('viewAdminIndex', Spatie\Tags\Tag::class)
+            <li class="breadcrumb-item active">
+                <a href="{{ route('tags.table') }}">All Tags</a>
+            </li>
+        @endcan
+        <li class="breadcrumb-item active" aria-current="page">
+            Edit Tag
+        </li>
+    @endpush
+    @include('breadcrumbs')
+@stop
+@section('content')
+
+<div class="container">
+    <h1><i class="fas fa-tags" aria-hidden="true"></i> Edit Tag {{ $tag->name }}</h1>
+
+    @include('errors/has')
+
+    @if (Session::has('admin'))
+		<div class="alert alert-success alert-dismissable" role="alert">
+			<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+			{{ session('admin') }}
+		</div>
+	@endif
+
+	@if (Session::has('editor'))
+		<div class="alert alert-success alert-dismissable" role="alert">
+			<button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+			{{ session('editor') }}
+		</div>
+	@endif
+
+    {!! Form::model($tag, ['method' => 'PATCH','route' => ['tags.updateTag', $tag], 'class' => 'form-horizontal' ]) !!}
+
+    <div class="form-group {{ ($errors->has('name') ?  'has-error' : '') }}">
+        {!! Form::label('name', 'Tag name(s)', ['class' => 'col-sm-2 control-label']) !!}
+        <div class="col-sm-9">
+            <span class="text-danger">{!! $errors->first('name') !!}</span>
+            {!! Form::text('name', null, ['class' => 'form-control']) !!}
+        </div>
+        <div class="col-sm-9">
+            <span class="text-danger">{!! $errors->first('type') !!}</span>
+            {!! Form::text('type', null, ['class' => 'form-control', 'readonly']) !!}
+        </div>
+    </div>
+
+	<!-- Submit Button -->
+        <div class="col-sm-9">
+            <a href="{{ route('tags.table') }}" class='btn btn-light'>Cancel</a>
+            {!! Form::submit('Update Tag', ['class' => 'btn btn-primary']) !!}
+		</div>
+	{!! Form::close() !!}
+</div>
+@stop

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@
  ******************/
 
 use App\Http\Controllers\ProfilesController;
+use App\Http\Controllers\TagsController;
 use App\Http\Controllers\UsersController;
 
 Route::name('login.show')->get('/login', 'Auth\LoginController@showLoginForm');
@@ -66,6 +67,11 @@ Route::name('tags.')->prefix('/tags')->group(function () {
     Route::name('store')->post('/store', 'TagsController@store');
     Route::name('api.search')->get('/api/search', 'TagsController@search');
     Route::name('api.update')->post('/api', 'TagsController@update');
+
+    Route::prefix('/{tag}')->group(function() {
+        Route::name('editTag')->get('editTag', [TagsController::class, 'editTag']);
+        Route::name('updateTag')->patch('updateTag', [TagsController::class, 'updateTag']);
+    });
 
 });
 


### PR DESCRIPTION
Adds the option to edit a tag name while validating its uniqueness by type. 

The edit and update URLs use the ID instead of the slug to ensure to retrieve the correct record. Searching by slug could potentially return an incorrect record in case there are existing tags with the same name. The Tag route binding was commented out in the RouteServiceProvider file, for future consideration.