### PR TITLE
Restrict access to non-public profiles

### DIFF
--- a/app/Http/Controllers/ProfilesApiController.php
+++ b/app/Http/Controllers/ProfilesApiController.php
@@ -18,16 +18,17 @@ class ProfilesApiController extends Controller
         // Set the response Cache-Control headers
         $this->middleware('cache.headers:' . config('app.api_cache_control'));
 
+        $this->middleware('can:view,profile')->only('show');
         // CORS middleware is auto-applied to all API routes
     }
 
     /**
-     * Get a listing of all Profiles.
+     * Get a listing of all public Profiles.
      */
     public function index(ProfilesApiRequest $request): JsonResponse
     {
         return Cache::tags(['profiles', 'profile_data', 'profile_tags'])->remember($request->fullUrl(), 3600, function() use ($request) {
-            $profile = Profile::select(Profile::apiAttributes())->with(['media']);
+            $profile = Profile::select(Profile::apiAttributes())->with(['media'])->public();
 
             if ($request->filled('person')) {
                 $profile = $profile->whereIn('slug', explode(';', $request->person));
@@ -51,14 +52,6 @@ class ProfilesApiController extends Controller
 
             if ($request->filled('tag')) {
                 $profile = $profile->withAnyTags(explode(';', $request->tag), Profile::class);
-            }
-
-            if ($request->filled('public')) {
-                if ($request->boolean('public')) {
-                    $profile = $profile->public();
-                } elseif ((bool)$request->input('public') === false) {
-                    $profile = $profile->private();
-                }
             }
 
             if ($request->boolean('with_data')) {

--- a/app/Http/Controllers/ProfilesController.php
+++ b/app/Http/Controllers/ProfilesController.php
@@ -44,6 +44,8 @@ class ProfilesController extends Controller
             'updateImage',
         ]);
 
+        $this->middleware('can:view,profile')->only('show');
+
         $this->middleware('can:export,profile')->only('pdfExport');
 
         $this->middleware('can.create.profile')->only('create');

--- a/app/Policies/ProfilePolicy.php
+++ b/app/Policies/ProfilePolicy.php
@@ -78,8 +78,12 @@ class ProfilePolicy
      * @param  \App\Profile  $profile
      * @return mixed
      */
-    public function view(User $user, Profile $profile)
+    public function view(?User $user, Profile $profile)
     {
+        if (request()->is('api/*')) {
+            return $profile->public;
+        }
+
         return true;
     }
 

--- a/app/Policies/ProfilePolicy.php
+++ b/app/Policies/ProfilePolicy.php
@@ -84,7 +84,11 @@ class ProfilePolicy
             return $profile->public;
         }
 
-        return true;
+        return $profile->public ||
+                $user->hasRole(['site_admin', 'profiles_editor']) ||
+                $user->owns($profile, true) ||
+                $this->checkSchoolEditor($user, $profile) ||
+                $this->checkDepartmentEditor($user, $profile);
     }
 
     /**

--- a/resources/views/profiles/edit/information.blade.php
+++ b/resources/views/profiles/edit/information.blade.php
@@ -313,7 +313,7 @@
 					</div>
 				</div>
 				<div class="col col-12 col-xl-5">
-					<p class="text-muted">Make profile viewable and searchable by website visitors. (If turned off, it will still be accessible to site administrators.)</p>
+					<p class="text-muted">Make profile viewable and searchable by website visitors. If turned off, it will still be accessible to site administrators.</p>
 				</div>
 			</fieldset>
 			{!! Form::submit('Save', array('class' => 'btn btn-primary edit-button')) !!}

--- a/resources/views/profiles/edit/information.blade.php
+++ b/resources/views/profiles/edit/information.blade.php
@@ -313,7 +313,7 @@
 					</div>
 				</div>
 				<div class="col col-12 col-xl-5">
-					<p class="text-muted">Make profile viewable and searchable by website visitors. (If turned off, it will still be accessible via the public API and to site administrators.)</p>
+					<p class="text-muted">Make profile viewable and searchable by website visitors. (If turned off, it will still be accessible to site administrators.)</p>
 				</div>
 			</fieldset>
 			{!! Form::submit('Save', array('class' => 'btn btn-primary edit-button')) !!}


### PR DESCRIPTION
This PR is to address the first vulnerability in the [HackerOne report](https://atlas.utdallas.edu/TDNext/Apps/38/Tickets/TicketDet?TicketID=412894)
- Removes `public` parameter from the profiles search
- The index endpoint returns only public profiles. In case that a requested profile is private, the search will return an empty array
- Adds conditional to the profile `view` policy to allow access based on whether the profile is public or not when the context is API. An 403 Forbidden error will be returned by the show endpoint when a private profile is requested.