### PR TITLE
Restrict access to view a user's bookmarks

### DIFF
--- a/app/Bookmark.php
+++ b/app/Bookmark.php
@@ -30,24 +30,4 @@ class Bookmark extends MorphPivot
         return $this->belongsTo(Profile::class, 'userable_id');
     }
 
-    /**
-     * This belongs to one user.
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
-     */
-    public function user()
-    {
-        return $this->belongsTo(User::class, 'user_id');
-    }
-
-    /**
-     * Bookmark belongs to a given user
-     * 
-     * @param User $user
-     * @return bool
-     */
-    public function ownerIs(User $user): bool
-    {
-        return $this->user_id === $user->id;
-    }
 }

--- a/app/Bookmark.php
+++ b/app/Bookmark.php
@@ -4,6 +4,8 @@ namespace App;
 
 use App\Profile;
 use App\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphPivot;
 
@@ -17,6 +19,18 @@ class Bookmark extends MorphPivot
 
     /** @var string The database table for this model. */
     public $table = 'bookmarks';
+
+    //////////////////
+    // Query Scopes //
+    //////////////////
+
+    /**
+     * Query scope to get bookmarks of a particular model type.
+     */
+    public function scopeOfType(Builder $q, Model|string $model): void
+    {
+        $q->where('userable_type', '=', is_object($model) ? get_class($model) : $model);
+    }
 
     //////////////
     // Relations//

--- a/app/Bookmark.php
+++ b/app/Bookmark.php
@@ -3,6 +3,8 @@
 namespace App;
 
 use App\Profile;
+use App\User;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphPivot;
 
 class Bookmark extends MorphPivot
@@ -22,12 +24,18 @@ class Bookmark extends MorphPivot
 
     /**
      * Bookmark has one Profile (one-to-one)
-     *
-     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
      */
-    public function profile()
+    public function profile(): BelongsTo
     {
         return $this->belongsTo(Profile::class, 'userable_id');
+    }
+
+    /**
+     * Bookmark(s) belong to one User (many-to-one)
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
     }
 
 }

--- a/app/Bookmark.php
+++ b/app/Bookmark.php
@@ -29,4 +29,25 @@ class Bookmark extends MorphPivot
     {
         return $this->belongsTo(Profile::class, 'userable_id');
     }
+
+    /**
+     * This belongs to one user.
+     *
+     * @return \Illuminate\Database\Eloquent\Relations\BelongsTo
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    /**
+     * Bookmark belongs to a given user
+     * 
+     * @param User $user
+     * @return bool
+     */
+    public function ownerIs(User $user): bool
+    {
+        return $this->user_id === $user->id;
+    }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -35,7 +35,9 @@ class UsersController extends Controller
 
         $this->middleware('can:viewAdminIndex,App\User')->only('index');
 
-        $this->middleware('can:view,user')->only(['show', 'showBookmarks']);
+        $this->middleware('can:view,user')->only('show');
+
+        $this->middleware('can:viewUserIndex,App\Bookmark,user')->only('showBookmarks');
 
         $this->middleware('can:create,App\User')->only([
             'create',

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -37,7 +37,7 @@ class UsersController extends Controller
 
         $this->middleware('can:view,user')->only('show');
 
-        $this->middleware('can:viewUserIndex,App\Bookmark,user')->only('showBookmarks');
+        $this->middleware('can:viewBookmarks,user')->only('showBookmarks');
 
         $this->middleware('can:create,App\User')->only([
             'create',

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -35,7 +35,7 @@ class UsersController extends Controller
 
         $this->middleware('can:viewAdminIndex,App\User')->only('index');
 
-        $this->middleware('can:view,user')->only('show');
+        $this->middleware('can:view,user')->only(['show', 'showBookmarks']);
 
         $this->middleware('can:create,App\User')->only([
             'create',

--- a/app/Http/Livewire/BookmarkButton.php
+++ b/app/Http/Livewire/BookmarkButton.php
@@ -2,11 +2,16 @@
 
 namespace App\Http\Livewire;
 
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Component;
 
 class BookmarkButton extends Component
 {
+    use AuthorizesRequests;
+
     public $model;
+
+    public $bookmark;
 
     public $user;
 
@@ -33,6 +38,10 @@ class BookmarkButton extends Component
 
     public function unbookmark()
     {
+        $bookmark = $this->user->bookmarks->where('userable_id', '=', $this->model->getKey())->first();
+
+        $this->authorize('delete', $bookmark);
+        
         $this->user->unbookmark($this->model);
 
         $this->emit('alert', "Removed from your bookmarks", 'success');

--- a/app/Http/Livewire/BookmarkButton.php
+++ b/app/Http/Livewire/BookmarkButton.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Livewire;
 
+use App\Policies\UserBookmarkPolicy;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Component;
 
@@ -31,6 +32,8 @@ class BookmarkButton extends Component
 
     public function bookmark()
     {
+        $this->authorize('create', 'App\Bookmark');
+
         $this->user->bookmark($this->model);
 
         $this->emit('alert', "Bookmarked!", 'success');

--- a/app/Http/Livewire/BookmarkButton.php
+++ b/app/Http/Livewire/BookmarkButton.php
@@ -12,8 +12,6 @@ class BookmarkButton extends Component
 
     public $model;
 
-    public $bookmark;
-
     public $user;
 
     public $mini = false;

--- a/app/Http/Livewire/BookmarkButton.php
+++ b/app/Http/Livewire/BookmarkButton.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Livewire;
 
-use App\Policies\UserBookmarkPolicy;
 use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
 use Livewire\Component;
 

--- a/app/Http/Livewire/BookmarkButton.php
+++ b/app/Http/Livewire/BookmarkButton.php
@@ -41,10 +41,8 @@ class BookmarkButton extends Component
 
     public function unbookmark()
     {
-        $bookmark = $this->user->bookmarks->where('userable_id', '=', $this->model->getKey())->first();
+        $this->authorize('delete', $this->user->bookmarkFor($this->model));
 
-        $this->authorize('delete', $bookmark);
-        
         $this->user->unbookmark($this->model);
 
         $this->emit('alert', "Removed from your bookmarks", 'success');

--- a/app/Policies/BookmarkPolicy.php
+++ b/app/Policies/BookmarkPolicy.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace App\Policies;
+
+use App\Bookmark;
+use App\User;
+
+class BookmarkPolicy
+{
+    // use HandlesAuthorization;
+
+    /**
+     * Runs before any other authorization checks
+     *
+     * @param User $user
+     * @param string $ability
+     * @return void|bool
+     */
+    public function before($user, $ability)
+    {
+        if ($user->hasRole('site_admin')) {
+            return true;
+        }
+    }
+
+    /**
+     * Determine whether a user can view their their own or another's user's bookmarks
+     *
+     * @param  User  $user
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function viewUserIndex(User $user)
+    {
+        $bookmarks_owner_requested = request()->route()->user;
+
+        foreach ($bookmarks_owner_requested->bookmarks as $bookmark) {
+            if(!$this->view($user, $bookmark))
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Determine whether the user can view the model.
+     *
+     * @param  User  $user
+     * @param  Bookmark  $bookmark
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function view(User $user, Bookmark $bookmark)
+    {
+        return $user->owns($bookmark) || $user->hasRole(['profiles_editor', 'school_profiles_editor', 'department_profiles_editor']);
+    }
+
+    /**
+     * Determine whether the user can create bookmarks.
+     *
+     * @param  \App\User  $user
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function create(User $user)
+    {
+        return true;
+    }
+
+    /**
+     * Determine whether the user can delete the bookmark.
+     *
+     * @param  \App\User  $user
+     * @param  \App\Bookmark $bookmark
+     * @return \Illuminate\Auth\Access\Response|bool
+     */
+    public function delete(User $user, Bookmark $bookmark)
+    {
+        return $user->owns($bookmark) || $user->hasRole('profiles_editor');
+    }
+}

--- a/app/Policies/UserBookmarkPolicy.php
+++ b/app/Policies/UserBookmarkPolicy.php
@@ -5,7 +5,7 @@ namespace App\Policies;
 use App\Bookmark;
 use App\User;
 
-class BookmarkPolicy
+class UserBookmarkPolicy
 {
     // use HandlesAuthorization;
 
@@ -24,34 +24,15 @@ class BookmarkPolicy
     }
 
     /**
-     * Determine whether a user can view their their own or another's user's bookmarks
+     * Determine whether the user can view the owner's bookmarks.
      *
      * @param  User  $user
+     * @param  User  $owner
      * @return \Illuminate\Auth\Access\Response|bool
      */
-    public function viewUserIndex(User $user)
+    public function viewBookmarks(User $user, User $owner)
     {
-        $bookmarks_owner_requested = request()->route()->user;
-
-        foreach ($bookmarks_owner_requested->bookmarks as $bookmark) {
-            if(!$this->view($user, $bookmark))
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Determine whether the user can view the model.
-     *
-     * @param  User  $user
-     * @param  Bookmark  $bookmark
-     * @return \Illuminate\Auth\Access\Response|bool
-     */
-    public function view(User $user, Bookmark $bookmark)
-    {
-        return $user->owns($bookmark) || $user->hasRole(['profiles_editor', 'school_profiles_editor', 'department_profiles_editor']);
+        return $user->is($owner);
     }
 
     /**
@@ -74,6 +55,6 @@ class BookmarkPolicy
      */
     public function delete(User $user, Bookmark $bookmark)
     {
-        return $user->owns($bookmark) || $user->hasRole('profiles_editor');
+        return $user->owns($bookmark);
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -71,6 +71,18 @@ class UserPolicy
     }
 
     /**
+     * Determine whether the user can view the owner's bookmarks.
+     *
+     * @param  \App\User  $user
+     * @param  \App\User  $model
+     * @return mixed
+     */
+    public function viewBookmarks(User $user, User $owner)
+    {
+        return $user->can('viewBookmarks', ['App\Bookmark', $owner]);
+    }
+
+    /**
      * Determine whether the user can create models.
      *
      * @param  \App\User  $user

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Bookmark;
 use App\Policies\LogPolicy;
 use App\Policies\ProfilePolicy;
 use App\Policies\SettingPolicy;
@@ -11,6 +12,7 @@ use App\Policies\UserPolicy;
 use App\Policies\UserDelegationPolicy;
 use App\LogEntry;
 use App\Policies\ProfileStudentPolicy;
+use App\Policies\BookmarkPolicy;
 use App\Profile;
 use App\ProfileStudent;
 use App\Setting;
@@ -37,6 +39,7 @@ class AuthServiceProvider extends ServiceProvider
         Tag::class => TagPolicy::class,
         User::class => UserPolicy::class,
         UserDelegation::class => UserDelegationPolicy::class,
+        Bookmark::class => BookmarkPolicy::class,
     ];
 
     /**

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -12,7 +12,7 @@ use App\Policies\UserPolicy;
 use App\Policies\UserDelegationPolicy;
 use App\LogEntry;
 use App\Policies\ProfileStudentPolicy;
-use App\Policies\BookmarkPolicy;
+use App\Policies\UserBookmarkPolicy;
 use App\Profile;
 use App\ProfileStudent;
 use App\Setting;
@@ -39,7 +39,7 @@ class AuthServiceProvider extends ServiceProvider
         Tag::class => TagPolicy::class,
         User::class => UserPolicy::class,
         UserDelegation::class => UserDelegationPolicy::class,
-        Bookmark::class => BookmarkPolicy::class,
+        Bookmark::class => UserBookmarkPolicy::class,
     ];
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -10,7 +10,7 @@ use App\Student;
 use App\UserSetting;
 use App\Traits\RoleTrait;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Illuminate\Support\Facades\DB;
+use Illuminate\Database\Eloquent\Model;
 use OwenIt\Auditing\Auditable as HasAudits;
 use OwenIt\Auditing\Contracts\Auditable;
 use Illuminate\Notifications\Notifiable;
@@ -125,6 +125,21 @@ class User extends Authenticatable implements Auditable
         }
 
         return $this->bookmarked($model)->where('userable_id', '=', $model->getKey())->exists();
+    }
+
+    /**
+     * Returns the User's Bookmark of the given model
+     */
+    public function bookmarkFor(Model $model): ?Bookmark
+    {
+        if ($this->relationLoaded('bookmarks')) {
+            return $this->bookmarks->firstWhere(function($bookmark) use ($model) {
+                return $bookmark->userable_id === $model->getKey() &&
+                       $bookmark->userable_type === get_class($model);
+            });
+        }
+
+        return $this->bookmarks()->ofType($model)->firstWhere('userable_id', '=', $model->getKey());
     }
 
     /**


### PR DESCRIPTION
To address vulnerability #2645780 – Low – [profiles.utdallas.edu] IDOR via "/users/[UserName]/boomarks" in the HackerOne report. 

Allow access to view a user's bookmarks only if: the logged in user is the owners of the bookmarks. 