### PR TITLE
Add CSRF token implementation for student app status update

### DIFF
--- a/resources/views/errors/419.blade.php
+++ b/resources/views/errors/419.blade.php
@@ -1,0 +1,16 @@
+@extends('layout')
+@section('title', 'Page Expired')
+@section('header')
+	@include('nav')
+@stop
+@section('content')
+
+<div class="jumbotron">
+	<div class="text-center">
+		<h2>419: Page Expired 😭</h2>
+	</div>
+</div>
+
+@include('errors/list')
+
+@stop

--- a/resources/views/students/show.blade.php
+++ b/resources/views/students/show.blade.php
@@ -36,20 +36,26 @@
                     </a>
                 </small>
             </h2>
-            <div class="mb-3 mb-md-0">
+            <div class="mb-3 mb-md-0 row">
                 @can('update', $student)
-                    <a class="btn btn-primary btn-sm" href="{{ route('students.edit', [$student]) }}"><i class="fas fa-edit"></i> Edit</a>
-                    @if($student->status === 'drafted')
-                        <a class="btn btn-secondary btn-sm" href="{{ route('students.status', ['student' => $student, 'status' => 'submitted']) }}" data-toggle="tooltip" data-placement="auto" title="Submit this student application for consideration"><i class="fas fa-check"></i> Submit</a>
-                    @else
-                        <a class="btn btn-secondary btn-sm" href="{{ route('students.status', ['student' => $student, 'status' => 'drafted']) }}" data-toggle="tooltip" data-placement="auto" title="Un-submit if you've already joined a research group or want to remove your application from future consideration"><i class="fas fa-undo"></i> Un-submit</a>
-                    @endif
+                    <div class="ml-3 mr-2"><a class="btn btn-primary btn-sm" href="{{ route('students.edit', [$student]) }}"><i class="fas fa-edit"></i> Edit</a></div>
+                    <div class="mr-2">
+                    {!! Form::open(['url' => route('students.status', $student), 'method' => 'PATCH']) !!}
+                        @if($student->status === 'drafted')
+                            {!!Form::hidden('status', 'submitted')!!}
+                            <button class="btn btn-secondary btn-sm" type="submit" data-toggle="tooltip" data-placement="auto" title="Submit this student application for consideration"><i class="fas fa-check"></i> Submit</button>
+                        @else
+                            {!!Form::hidden('status', 'drafted')!!}
+                            <button class="btn btn-secondary btn-sm" type="submit" data-toggle="tooltip" data-placement="auto" title="Un-submit if you've already joined a research group or want to remove your application from future consideration"><i class="fas fa-undo"></i> Un-submit</button>
+                        @endif
+                    {!! Form::close() !!}
+                    </div>
                 @endcan
                 @if(!auth()->user()->owns($student))
                     <livewire:bookmark-button :model="$student">
                 @endif
                 @can('viewFeedback', $student)
-                    <a class="btn btn-primary btn-sm" href="#student_feedback"><i class="fas fa-comment"></i> Feedback</a>
+                    <div class="mr-2"><a class="btn btn-primary btn-sm" href="#student_feedback"><i class="fas fa-comment"></i> Feedback</a></div>
                 @endcan
             </div>
         </div>

--- a/resources/views/students/show.blade.php
+++ b/resources/views/students/show.blade.php
@@ -42,11 +42,9 @@
                     <div class="mr-2">
                     {!! Form::open(['url' => route('students.status', $student), 'method' => 'PATCH']) !!}
                         @if($student->status === 'drafted')
-                            {!!Form::hidden('status', 'submitted')!!}
-                            <button class="btn btn-secondary btn-sm" type="submit" data-toggle="tooltip" data-placement="auto" title="Submit this student application for consideration"><i class="fas fa-check"></i> Submit</button>
+                            <button class="btn btn-secondary btn-sm" type="submit" name="status" value="submitted" data-toggle="tooltip" data-placement="auto" title="Submit this student application for consideration"><i class="fas fa-check"></i> Submit</button>
                         @else
-                            {!!Form::hidden('status', 'drafted')!!}
-                            <button class="btn btn-secondary btn-sm" type="submit" data-toggle="tooltip" data-placement="auto" title="Un-submit if you've already joined a research group or want to remove your application from future consideration"><i class="fas fa-undo"></i> Un-submit</button>
+                            <button class="btn btn-secondary btn-sm" type="submit" name="status" value="drafted" data-toggle="tooltip" data-placement="auto" title="Un-submit if you've already joined a research group or want to remove your application from future consideration"><i class="fas fa-undo"></i> Un-submit</button>
                         @endif
                     {!! Form::close() !!}
                     </div>

--- a/routes/components/students.php
+++ b/routes/components/students.php
@@ -17,7 +17,7 @@ Route::name('students.')->prefix('/students')->group(function () {
         Route::name('show')->get('/', [StudentsController::class, 'show']);
         Route::name('edit')->get('/edit', [StudentsController::class, 'edit']);
         Route::name('update')->post('/update', [StudentsController::class, 'update']);
-        Route::name('status')->get('/status', [StudentsController::class, 'setStatus']);
+        Route::name('status')->patch('/status', [StudentsController::class, 'setStatus']);
     });
 
 });

--- a/tests/Feature/StudentTest.php
+++ b/tests/Feature/StudentTest.php
@@ -105,7 +105,7 @@ class StudentTest extends TestCase
             ->assertViewIs('students.show')
             ->assertSee('Un-submit');
 
-        $this->followingRedirects()->get($unsubmit_route)
+        $this->followingRedirects()->patch($unsubmit_route)
             ->assertStatus(200)
             ->assertSee('Student profile status updated');
 


### PR DESCRIPTION
To address CSRF vulnerability #2641316 – Low – [profiles.utdallas.edu] CSRF at "/students/[VictimUsername]/status?status=drafted" in the HackerOne report.

Replaces the `<a>` tag in the student form to update the student application status for a `<form>` element that contains the CSRF token used by the `VerifyCsrfToken` middleware. Manual testing confirms that requests with an invalid or missing CSRF token return a 419 HTTP response.