### PR TITLE
Enable Profile Editor Roles to Manage Profiles With Multiple Schools or Departments

### DIFF
--- a/app/Policies/ProfilePolicy.php
+++ b/app/Policies/ProfilePolicy.php
@@ -34,12 +34,9 @@ class ProfilePolicy
      */
     protected function checkSchoolEditor(User $user, Profile $profile)
     {
-        // return $user->hasRoleOption('school_profiles_editor', 'schools', $profile->user->school_id ?? -1);
-        $profile_linked_schools = $profile->user->schools->pluck('id');
+        $profile_schools = $profile->user->schools;
 
-        foreach ($profile_linked_schools as $school_id) {
-            return $user->hasRoleOption('school_profiles_editor', 'schools', $school_id ?? -1);
-        }
+        return $profile_schools->contains(fn($school) => $user->hasRoleOption('school_profiles_editor', 'schools', $school->id ?? -1));
     }
 
     /**
@@ -51,7 +48,9 @@ class ProfilePolicy
      */
     protected function checkDepartmentEditor(User $user, Profile $profile)
     {
-        return $user->hasRoleOption('department_profiles_editor', 'departments', $profile->user->department ?? 'none');
+        $profile_departments = $profile->user->departments;
+
+        return $profile_departments->contains(fn($department) => $user->hasRoleOption('department_profiles_editor', 'departments', $department ?? 'none'));
     }
 
     /**

--- a/app/Policies/ProfilePolicy.php
+++ b/app/Policies/ProfilePolicy.php
@@ -34,7 +34,12 @@ class ProfilePolicy
      */
     protected function checkSchoolEditor(User $user, Profile $profile)
     {
-        return $user->hasRoleOption('school_profiles_editor', 'schools', $profile->user->school_id ?? -1);
+        // return $user->hasRoleOption('school_profiles_editor', 'schools', $profile->user->school_id ?? -1);
+        $profile_linked_schools = $profile->user->schools->pluck('id');
+
+        foreach ($profile_linked_schools as $school_id) {
+            return $user->hasRoleOption('school_profiles_editor', 'schools', $school_id ?? -1);
+        }
     }
 
     /**


### PR DESCRIPTION
- Fixes issue #52

1. Updates the `checkSchoolEditor(User $user, Profile $profile)` to verify the user's ability to edit profiles with multiple schools
2. Updates the `checkDepartmentEditor(User $user, Profile $profile)` to verify the user's ability to edit profiles with multiple departments 