### PR TITLE
Fix Profiles API Validation Error For Empty `data_type`

### DIFF
--- a/app/Http/Requests/ProfilesApiRequest.php
+++ b/app/Http/Requests/ProfilesApiRequest.php
@@ -38,6 +38,8 @@ class ProfilesApiRequest extends FormRequest
             'raw_data' => 'sometimes|boolean',
             'data_type' => [
                 'sometimes',
+                'filled',
+                'string',
                 new AllowedProfileDataType(),
             ],
         ];

--- a/app/Http/Requests/ProfilesApiRequest.php
+++ b/app/Http/Requests/ProfilesApiRequest.php
@@ -39,7 +39,6 @@ class ProfilesApiRequest extends FormRequest
             'data_type' => [
                 'sometimes',
                 'filled',
-                'string',
                 new AllowedProfileDataType(),
             ],
         ];

--- a/app/Rules/AllowedProfileDataType.php
+++ b/app/Rules/AllowedProfileDataType.php
@@ -22,6 +22,9 @@ class AllowedProfileDataType implements InvokableRule
         if (is_string($value)) {
             $value = explode(';', $value);
         }
+        else {
+            $fail('The :attribute must be a string.');
+        }
 
         foreach ($value as $data_type) {
             if (!in_array($data_type, $allowed_data_types)) {


### PR DESCRIPTION
Ensure `data_type` is not empty when present and that is a string.
This fix addresses [Sentry error PROFILES-6J](https://ut-dallas-research.sentry.io/issues/5802999544/?alert_rule_id=401010&alert_timestamp=1725577507276&alert_type=email&environment=production&notification_uuid=ab24b417-961a-4b7f-9ea7-e628c2a73ecb&project=1057311&referrer=alert_email)