### PR TITLE
Replace Student Table Slug Values with ULIDs

### DIFF
--- a/app/Http/Controllers/StudentsController.php
+++ b/app/Http/Controllers/StudentsController.php
@@ -13,6 +13,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\View\View;
+use Illuminate\Support\Str;
 
 class StudentsController extends Controller
 {
@@ -71,7 +72,7 @@ class StudentsController extends Controller
         $user = $request->user();
 
         $student = $user->studentProfiles()->create([
-            'slug' => $user->pea,
+            'slug' => Str::ulid(),
             'full_name' => $user->display_name,
             'first_name' => $user->firstname,
             'last_name' => $user->lastname,

--- a/database/seeders/v2_1_Seeder.php
+++ b/database/seeders/v2_1_Seeder.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Student;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class v2_1_Seeder extends Seeder
+{
+    /**
+     * Updates student records by chunks
+     */
+    public function run(): void 
+    {
+        Student::query()
+            ->whereNotNull('slug')
+            ->orderBy('id')
+            ->chunkById(200, function ($students) {
+                $this->command->withProgressBar($students, fn($student) => $this->updateStudent($student));
+                $this->command->newLine();
+            });
+    }
+
+    /**
+     * Replaces a student slug with a unique ULID
+     */
+    public function updateStudent(Student $student): void
+    {
+        $existing_student = DB::table('students')->where('id', $student->id) ?? null;
+
+        if ($existing_student) {
+            $existing_student->update(['slug' => Str::ulid()]);
+        }
+    }
+}


### PR DESCRIPTION
Adds seeder to replace current slug values for the student table with a ULID.
Generates a ULID for new student records.