### PR TITLE
Exports Student Applications to CSV

### DIFF
--- a/app/Http/Livewire/ProfileStudents.php
+++ b/app/Http/Livewire/ProfileStudents.php
@@ -87,7 +87,7 @@ class ProfileStudents extends Component
         $this->students = $this->getStudentsProperty();
     }
 
-    public function export()
+    public function exportToCsv()
     {
         $students = $this->students->where('application.status', $this->filing_status);
 
@@ -95,7 +95,7 @@ class ProfileStudents extends Component
             $this->emit('alert', "No records available for the filters applied", 'danger');
         }
         else {
-            $student_apps = Student::exportStudentApps($students, 'student_applications.csv');
+            $student_apps = Student::exportStudentApps($students);
             return $student_apps->toCsv('students_apps.csv');
         }
     }

--- a/app/Http/Livewire/ProfileStudents.php
+++ b/app/Http/Livewire/ProfileStudents.php
@@ -56,7 +56,7 @@ class ProfileStudents extends Component
         'semester_filter' => ['except' => '', 'as' => 'semester'],
     ];
 
-    public function getStudentsProperty()
+    public function getStudentsBuilderProperty()
     {
         return $this->profile->students()
             ->submitted()
@@ -71,8 +71,12 @@ class ProfileStudents extends Component
             ->willWorkWithAnimals($this->animals_filter)
             ->needsResearchCredit($this->credit_filter)
             ->with('user:id,email')
-            ->orderBy('last_name')
-            ->get();
+            ->orderBy('last_name');
+    }
+
+    public function getStudentsProperty()
+    {
+        return $this->getStudentsBuilderProperty()->get();
     }
 
     public function updated($name, $value)
@@ -83,6 +87,11 @@ class ProfileStudents extends Component
     public function refreshStudents()
     {
         $this->students = $this->getStudentsProperty();
+    }
+
+    public function export()
+    {
+        return $this->getStudentsBuilderProperty()->toCsv();
     }
 
     public function render()

--- a/app/Macros/CollectionMacros.php
+++ b/app/Macros/CollectionMacros.php
@@ -1,0 +1,36 @@
+<?php
+namespace App\Macros;
+
+use Illuminate\Support\Collection;
+
+class CollectionMacros
+{
+    public static function register()
+    {
+        Collection::macro('toCsv', function ($name = null) {
+            $results = $this;
+
+            return response()->streamDownload(function () use ($results) {
+                if ($results->isEmpty()) return;
+
+                $titles = implode(',', array_keys((array) $results->first()->getAttributes()));
+
+                $values = $results->map(function ($result) {
+                    return collect($result->getAttributes())->map(function ($value) {
+                        if (is_null($value)) return '""';
+
+                        $value = (string) $value;
+                        $value = str_replace(['\\r', '\\n', '\\t'], ' ', $value);
+                        $value = preg_replace('/\s+/', ' ', $value);
+                        $value = str_replace('"', '""', $value);
+
+                        return "\"{$value}\"";
+                    })->implode(',');
+                });
+
+                $values->prepend($titles);
+                echo $values->implode("\n");
+            }, $name ?? 'export.csv');
+        });
+    }
+}

--- a/app/Macros/CollectionMacros.php
+++ b/app/Macros/CollectionMacros.php
@@ -7,7 +7,15 @@ class CollectionMacros
 {
     public static function register()
     {
+        /**
+         * Adds a macro to export the collection to a streamed CSV response.
+         *
+         * @param string|null $name The name of the CSV file to download. Defaults to 'export.csv'.
+         * @return \Symfony\Component\HttpFoundation\StreamedResponse
+         */
         Collection::macro('toCsv', function ($name = null) {
+
+            /** @var \Illuminate\Support\Collection $this */
             $results = $this;
 
             return response()->streamDownload(function () use ($results) {
@@ -20,7 +28,7 @@ class CollectionMacros
                         if (is_null($value)) return '""';
 
                         $value = (string) $value;
-                        $value = str_replace(['\\r', '\\n', '\\t'], ' ', $value);
+                        $value = str_replace(["\r", "\n", "\t"], ' ', $value);
                         $value = preg_replace('/\s+/', ' ', $value);
                         $value = str_replace('"', '""', $value);
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Macros\CollectionMacros;
 use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Pagination\Paginator;
@@ -9,7 +10,6 @@ use Illuminate\Support\Facades\View;
 use App\Setting;
 use Collective\Html\FormFacade as Form;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Database\Eloquent\Builder;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -47,28 +47,7 @@ class AppServiceProvider extends ServiceProvider
             view()->share('settings', $settings);
         });
 
-        Builder::macro('toCsv', function ($name = null) {
-            $query = $this;
-
-            return response()->streamDownload(function () use ($query) {
-                $results = $query->get();
-
-                if ($results->count() < 1) return;
-
-                $titles = implode(',', array_keys((array) $results->first()->getAttributes()));
-
-                $values = $results->map(function ($result) {
-                    return implode(',', collect($result->getAttributes())->map(function ($thing) {
-                        return '"'.$thing.'"';
-                    })->toArray());
-                });
-
-                $values->prepend($titles);
-
-                echo $values->implode("\n");
-            }, $name ?? 'export.csv');
-        });
-
+        CollectionMacros::register();
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\View;
 use App\Setting;
 use Collective\Html\FormFacade as Form;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Database\Eloquent\Builder;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -44,6 +45,28 @@ class AppServiceProvider extends ServiceProvider
                 return Setting::pluck('value', 'name')->toArray();
             });
             view()->share('settings', $settings);
+        });
+
+        Builder::macro('toCsv', function ($name = null) {
+            $query = $this;
+
+            return response()->streamDownload(function () use ($query) {
+                $results = $query->get();
+
+                if ($results->count() < 1) return;
+
+                $titles = implode(',', array_keys((array) $results->first()->getAttributes()));
+
+                $values = $results->map(function ($result) {
+                    return implode(',', collect($result->getAttributes())->map(function ($thing) {
+                        return '"'.$thing.'"';
+                    })->toArray());
+                });
+
+                $values->prepend($titles);
+
+                echo $values->implode("\n");
+            }, $name ?? 'export.csv');
         });
 
     }

--- a/app/Student.php
+++ b/app/Student.php
@@ -127,7 +127,7 @@ class Student extends Model implements Auditable
 
     public static function exportStudentApps(EloquentCollection $students)
     {
-        $students->map(function ($student) {
+        $apps = $students->map(function ($student) {
             
             $st = clone $student;
 
@@ -192,7 +192,7 @@ class Student extends Model implements Auditable
             return $st;
         });
 
-        return $students;
+        return $apps;
     }
 
     /**

--- a/app/Student.php
+++ b/app/Student.php
@@ -125,6 +125,14 @@ class Student extends Model implements Auditable
         }
     }
 
+    /**
+     * Transforms a collection of students with their associated 'user' and 'research_profile' 
+     * data into a flat collection suitable for CSV export.
+     * 
+     * @param \Illuminate\Database\Eloquent\Collection $students
+     * @return \Illuminate\Support\Collection
+     * 
+     */
     public static function exportStudentApps(EloquentCollection $students)
     {
         $apps = $students->map(function ($student) {

--- a/resources/views/livewire/profile-students.blade.php
+++ b/resources/views/livewire/profile-students.blade.php
@@ -1,6 +1,15 @@
 <div class="row">
-    <div class="col-md-1 offset-md-11 mb-3 p-1">
-        <button class="btn btn-primary" wire:click="export"> Export</button>
+    <div class="col-12 d-flex justify-content-end mr-2 mb-2">
+        <button 
+            class="btn btn-primary btn-sm"
+            wire:click="exportToCsv"
+            type="button"
+            aria-label="Download student data as CSV"
+            title="Download as CSV"
+        >
+            <i class="fas fa-download"></i>
+            CSV
+        </button>
     </div>
     <div class="col-md-3 mb-md-0 mb-3">
         <div

--- a/resources/views/livewire/profile-students.blade.php
+++ b/resources/views/livewire/profile-students.blade.php
@@ -1,4 +1,7 @@
 <div class="row">
+    <div class="col-md-1 offset-md-11 mb-3 p-1">
+        <button class="btn btn-primary" wire:click="export"> Export</button>
+    </div>
     <div class="col-md-3 mb-md-0 mb-3">
         <div
             class="nav flex-column nav-pills h-100 border-right bg-light"

--- a/resources/views/livewire/profile-students.blade.php
+++ b/resources/views/livewire/profile-students.blade.php
@@ -21,6 +21,7 @@
                     aria-controls="tab_{{ Str::slug($status) }}"
                     aria-selected="{{ $loop->first ? 'true' : 'false' }}"
                     wire:ignore.self
+                    wire:click="$set('filing_status', @js($status))"
                 >
                     <span class="fa-fw mr-2 {{ $status_icons[$status] }}" style="opacity:0.3"></span>
                     {{ $status_name }}


### PR DESCRIPTION
- Addresses issue #187 
- Adds the `toCsv()` macro to Illuminate\Support\Collection to export collection's data in CSV format
- Adds the `export()` method to the `ProfileStudents` Livewire component to prepare and export filtered applications for the filing status selected in CSV format